### PR TITLE
Assume [ng-app] as root instead of <body>

### DIFF
--- a/Panel/PreprocessorPanel.js
+++ b/Panel/PreprocessorPanel.js
@@ -49,7 +49,7 @@
                 watchCount+= getWatchCount(scope.$$nextSibling, scopeHash);
 
                 return watchCount;
-            })(angular.element( window.document.querySelector('body') ).scope());
+            })(angular.element( window.document.querySelector('[ng-app]') ).scope());
         };
 
         window.lastCount = 0;


### PR DESCRIPTION
Counters did not work if ng-app was not actually in the body but a child
element.

Possible fix to #3.
